### PR TITLE
Add graph data structure based on hash map

### DIFF
--- a/src/graph-theory/edge.h
+++ b/src/graph-theory/edge.h
@@ -1,0 +1,40 @@
+/**
+ *  Project  Graph
+ *
+ *  This file contains an implementation of the graph edge.
+ *
+ *  @author  Roman Zelinskyi <lord.zelinskyi@gmail.com>
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace cppgraph {
+
+template<class Node>
+class Edge
+{
+public:
+    Edge(const Node& node, double w)
+        : _destNode{std::cref(node)}
+        , _weight{w}
+    {
+    }
+
+    const Node& destNode() const noexcept
+    {
+        return _destNode.get();
+    }
+
+    double weight() const noexcept
+    {
+        return _weight;
+    }
+
+private:
+    std::reference_wrapper<const Node> _destNode;
+    double _weight;
+};
+
+} // namespace cppgraph

--- a/src/graph-theory/graph.h
+++ b/src/graph-theory/graph.h
@@ -1,0 +1,59 @@
+/**
+ *  Project  Graph
+ *
+ *  @author  Roman Zelinskyi <lord.zelinskyi@gmail.com>
+ */
+
+#pragma once
+
+#include <forward_list>
+#include <stdexcept>
+#include <unordered_map>
+
+#include "edge.h"
+
+namespace cppgraph {
+
+template<class Node>
+class Graph
+{
+public:
+    Graph()
+        : _adjList{}
+    {
+    }
+
+    void addNode(const Node& node)
+    {
+        if (_adjList.count(node))
+            throw std::invalid_argument{"The node already exist"};
+
+        _adjList[node] = {};
+    }
+
+    void addEdge(const Node& src, const Node& dest, double weight = 0)
+    {
+        if (!_adjList.count(src) || !_adjList.count(dest))
+            throw std::invalid_argument{"No such node exist in graph"};
+
+        auto& srcNode = _adjList.at(src);
+        const auto& destNode = _adjList.find(dest)->first;
+        srcNode.push_front({destNode, weight});
+    }
+
+    void print()
+    {
+        for (const auto& it : _adjList) {
+            std::cout << it.first << "-> ";
+            for (const auto& adjecent : it.second)
+                std::cout << '[' << adjecent.destNode() << ',' << adjecent.weight() << ']' << ' ';
+
+            std::cout << '\n';
+        }
+    }
+
+private:
+    std::unordered_map<Node, std::forward_list<Edge<Node>>> _adjList;
+};
+
+} // namespace cppgraph


### PR DESCRIPTION
Added class Graph that will represent adjecency list
based graph using Node as key to hash map, and
forward_list as adjecent nodes.

Signed-off-by: Roman Zelinskyi <lord.zelinskyi@gmail.com>